### PR TITLE
Py3 compatibility for signature verification

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -22,7 +22,7 @@ class Webhook(object):
 
         self._hooks = collections.defaultdict(list)
         self._logger = logging.getLogger('webhook')
-        if secret and not isinstance(secret, six.binary_type):
+        if secret is not None and not isinstance(secret, six.binary_type):
             secret = secret.encode('utf-8')
         self._secret = secret
 

--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import logging
 
+import six
 from flask import abort, request
 
 
@@ -21,6 +22,8 @@ class Webhook(object):
 
         self._hooks = collections.defaultdict(list)
         self._logger = logging.getLogger('webhook')
+        if secret and not isinstance(secret, six.binary_type):
+            secret = secret.encode('utf-8')
         self._secret = secret
 
     def hook(self, event_type='push'):
@@ -50,9 +53,11 @@ class Webhook(object):
 
         if digest is not None:
             sig_parts = _get_header('X-Hub-Signature').split('=', 1)
+            if not isinstance(digest, six.text_type):
+                digest = six.text_type(digest)
 
             if (len(sig_parts) < 2 or sig_parts[0] != 'sha1'
-                    or not hmac.compare_digest(sig_parts[1], unicode(digest))):
+                    or not hmac.compare_digest(sig_parts[1], digest)):
                 abort(400, 'Invalid signature')
 
         event_type = _get_header('X-Github-Event')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(name="github-webhook",
       author_email="achamberlai9@bloomberg.net, fphillips7@bloomberg.net, dkiss1@bloomberg.net, dbeer1@bloomberg.net",
       license='Apache 2.0',
       packages=["github_webhook"],
-      install_requires=['flask'],
+      install_requires=['flask', 'six'],
+      tests_require=['mock', 'nose'],
 
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
This was what was minimally required to get signature verification to work under python 3.6.  Unit tests passed under 3.5, 3.6, and 2.7.