### PR TITLE
Add concurrent `hook` executor in `/postreceive` view_func

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name="github-webhook",
       author_email="achamberlai9@bloomberg.net, fphillips7@bloomberg.net, dkiss1@bloomberg.net, dbeer1@bloomberg.net",
       license='Apache 2.0',
       packages=["github_webhook"],
-      install_requires=['flask', 'six'],
+      install_requires=['flask', 'six', 'future;python_version<"3"'],
       tests_require=['mock', 'nose'],
 
       classifiers=[


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7189225/24942459/b87e220c-1f83-11e7-8e18-d6bdfdcfe6e7.png)

When the client sends requests, the process on the server side will block until all hook functions finished, so the client won't get timely respond (sometimes we run long shell scripts in the hook to deploy) and can't figure out what happen on the server either. In fact, we don't need the respond data, right? why not let it return in time.


Maybe we need further discussion.