### PR TITLE
Support multiple webhooks on a single flask app

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -17,7 +17,7 @@ class Webhook(object):
     """
 
     def __init__(self, app, endpoint='/postreceive', secret=None):
-        app.add_url_rule(endpoint, view_func=self._postreceive,
+        app.add_url_rule(rule=endpoint, endpoint=endpoint, view_func=self._postreceive,
                          methods=['POST'])
 
         self._hooks = collections.defaultdict(list)


### PR DESCRIPTION
When `endpoint` argument is not passed to `app.add_url_rule`, flask uses `view_func.__name__` to uniquely identify callbacks. This results in all callbacks having the same "unique" idenfitier: `_postreceive`.

An easy fix is to explicitly pass in an endpoint name, which can be identical to rule name.

Signed-Off-By: Frederic Spieler <fspieler@bloomberg.net>