### PR TITLE
Add method to set secret after Webhook.__init__

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -21,7 +21,18 @@ class Webhook(object):
 
         self._hooks = collections.defaultdict(list)
         self._logger = logging.getLogger("webhook")
-        if secret is not None and not isinstance(secret, six.binary_type):
+        if secret is not None:
+            self.set_secret(secret)
+        else:
+            self._secret = None
+
+    def set_secret(self, secret):
+        """
+        Set secret value for the webhook
+
+        :param secret: secret used to authenticate the hook comes from Github
+        """
+        if not isinstance(secret, six.binary_type):
             secret = secret.encode("utf-8")
         self._secret = secret
 


### PR DESCRIPTION
Currently a secret can only be set when the Webhook object is
initialized. However, this limits your options for how you can load in
the secret. For example, if a user's flask app parses a config file
using the flask before_first_request decorator and they wanted to store
the secret in that config file, then the only way to edit the value of
the secret is by directly setting a private attribute of the object
after initialization. This commit attemps to address this issue and
support the use case where the config is after the Webhook object is
initialized. It does this by adding a new public method, set_secret(),
which can be used to set the set secret value for the webhook object
just as if it was passed in as a kwarg to __init__().

Signed-off-by: Matthew Treinish <mtreinish@kortar.org>