### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+.tox/*
+*.pyc
+.coverage*
+!.coveragerc
+*egg*


### PR DESCRIPTION
As part of the normal process of developing python-github-webhook local
artifacts are generated from running python code, running tox, and
running tests. These are not things that should be committed to the
repo. To avoid accidents or mistakes when a file that shouldn't ever be
added to the repo is included in a commit this commit adds a .gitignore
file and configures it to not include any of these artifacts of normal
development. This way including a file like that by mistake is not
likely to ever happen.

Signed-off-by: Matthew Treinish <mtreinish@kortar.org>