### PR TITLE
Added support for 'application/x-www-form-urlencoded'

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -2,6 +2,7 @@ import collections
 import hashlib
 import hmac
 import logging
+import json
 
 import six
 from flask import abort, request
@@ -58,7 +59,12 @@ class Webhook(object):
                 abort(400, "Invalid signature")
 
         event_type = _get_header("X-Github-Event")
-        data = request.get_json()
+        content_type = _get_header('content-type')
+
+        if content_type == "application/x-www-form-urlencoded":
+            data = json.loads(request.form.to_dict(flat=True)["payload"])
+        else:
+            data = request.get_json()
 
         if data is None:
             abort(400, "Request body must contain json")
@@ -120,7 +126,6 @@ def _format_event(event_type, data):
         return EVENT_DESCRIPTIONS[event_type].format(**data)
     except KeyError:
         return event_type
-
 
 # -----------------------------------------------------------------------------
 # Copyright 2015 Bloomberg Finance L.P.


### PR DESCRIPTION
Currently this library supports only 'application/json' as content-type, This PR aims in adding support to the other content-type supported by Github for webhooks i.e. 'application/x-www-form-urlencoded'.

This support makes python-github-webhook fully compatible with the github webhooks.
    
Signed-Off-By: Shibani Mahapatra <shibani.mahapatra47@gmail.com>
