### PR TITLE
Added support for 'application/x-www-form-urlencoded'

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -2,7 +2,7 @@ import collections
 import hashlib
 import hmac
 import logging
-
+import json
 import six
 from flask import abort, request
 
@@ -58,7 +58,12 @@ class Webhook(object):
                 abort(400, "Invalid signature")
 
         event_type = _get_header("X-Github-Event")
-        data = request.get_json()
+        content_type = _get_header("content-type")
+        data = (
+            json.loads(request.form.to_dict(flat=True)["payload"])
+            if content_type == "application/x-www-form-urlencoded"
+            else request.get_json()
+        )
 
         if data is None:
             abort(400, "Request body must contain json")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="github-webhook",
-    version="1.0.2",
+    version="1.0.3",
     description="Very simple, but powerful, microframework for writing Github webhooks in Python",
     url="https://github.com/bloomberg/python-github-webhook",
     author="Alex Chamberlain, Fred Phillips, Daniel Kiss, Daniel Beer",


### PR DESCRIPTION
Currently this library supports only 'application/json' as content-type, This PR aims in adding support to the other content-type supported by Github for webhooks i.e. 'application/x-www-form-urlencoded'.

This support makes python-github-webhook fully compatible with the github webhooks.

Signed-Off-By: Shibani Mahapatra <shibani.mahapatra47@gmail.com>