### PR TITLE
Modify _get_digest to use request.get_data().

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -86,7 +86,7 @@ class Webhook(object):
         self._logger.info("%s (%s)", _format_event(event_type, data), _get_header("X-Github-Delivery"))
 
         for hook in self._hooks.get(event_type, []):
-            hook(data)
+            await hook(data)
 
         return "", 204
 

--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -42,7 +42,7 @@ class Webhook(object):
     def _get_digest(self):
         """Return message digest if a secret key was provided"""
 
-        return hmac.new(self._secret, request.data, hashlib.sha1).hexdigest() if self._secret else None
+        return hmac.new(self._secret, request.get_data(), hashlib.sha1).hexdigest() if self._secret else None
 
     def _postreceive(self):
         """Callback from Flask"""

--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -73,8 +73,9 @@ class Webhook(object):
 
         event_type = _get_header("X-Github-Event")
         content_type = _get_header("content-type")
+        form_data = await request.form
         data = (
-            json.loads(request.form.to_dict(flat=True)["payload"])
+            json.loads(form_data.to_dict(flat=True)["payload"])
             if content_type == "application/x-www-form-urlencoded"
             else request.get_json()
         )

--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -4,7 +4,7 @@ import hmac
 import logging
 import json
 import six
-from flask import abort, request
+from quart import abort, request
 
 
 class Webhook(object):
@@ -58,7 +58,7 @@ class Webhook(object):
 
         return hmac.new(self._secret, request.get_data(), hashlib.sha1).hexdigest() if self._secret else None
 
-    def _postreceive(self):
+    async def _postreceive(self):
         """Callback from Flask"""
 
         digest = self._get_digest()

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name="github-webhook",
-    version="1.0.4",
+    version="1.0.5",
     description="Very simple, but powerful, microframework for writing Github webhooks in Python",
     url="https://github.com/bloomberg/python-github-webhook",
     author="Alex Chamberlain, Fred Phillips, Daniel Kiss, Daniel Beer",
     author_email="achamberlai9@bloomberg.net, fphillips7@bloomberg.net, dkiss1@bloomberg.net, dbeer1@bloomberg.net",
     license="Apache 2.0",
     packages=["github_webhook"],
-    install_requires=["flask", "six"],
+    install_requires=["quart", "six"],
     tests_require=["mock", "pytest"],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
**Describe your changes**
This is a follow on to commit 8d3ad248126c15195d0f21b436ca05b3718bc255:

* request.data is empty when the content type of the payload is application/x-www-form-urlencoded, because the payload is parsed by Flask into request.form. 

* request.get_data() contains the contents of the request body that Flask cached. This works for application/json as well, because GitHub computes the signature over the request body in both cases. 

**Testing performed**
I have tested this manually by issuing Github Webhooks to a local development server. 

