### PR TITLE
Clarify example with how to specify event_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ webhook = Webhook(app) # Defines '/postreceive' endpoint
 def hello_world():
     return "Hello, World!"
 
-@webhook.hook()        # Defines a handler for the 'push' event
+@webhook.hook("push")  # Defines a handler for the 'push' event
 def on_push(data):
     print("Got push with: {0}".format(data))
 


### PR DESCRIPTION
It wasn't clear that a webhook's `event_type` is specified by the decorator argument, rather than the name of the function. I tried defining:

```
@webhook.hook()
def on_issue_comment(data):
   print(data)
```

But this still fires for `push` events. Instead, if we explicitly add the argument to the decorator here, it's clear that that's the way to change which webhook event type this method fires for.