### PR TITLE
Create self._hooks in __init__ to allow delayed calls to init_app()

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -17,14 +17,14 @@ class Webhook(object):
     """
 
     def __init__(self, app=None, endpoint="/postreceive", secret=None):
-        self.app = app
+        self._hooks = collections.defaultdict(list)
         self.secret = secret
         if app is not None:
             self.init_app(app, endpoint, secret)
 
     def init_app(self, app, endpoint="/postreceive", secret=None):
-        self._hooks = collections.defaultdict(list)
         self._logger = logging.getLogger("webhook")
+        self.app = app
         if secret is not None:
             self.secret = secret
         app.add_url_rule(rule=endpoint, endpoint=endpoint, view_func=self._postreceive, methods=["POST"])


### PR DESCRIPTION
A useful pattern with Flask extensions is to instantiate the extension in
a separate module, then import that in wsgi.py, calling ext.init_app(app)
there. This way, in the case of github_webhook e.g., webhooks can be defined
(decorated) in a separate module, before the Flask app has even been created.

For this to work, however, self._hooks (which is used by the decorator) must
be defined even if no app was given at instantiationtime. Previously, it was
only being created as part of init_app().

This commit:

  - creates self._hooks early, in Webhook.__init__

  - defines self.app in init_app(), so that it does not stay as None if
    init_app() is called in a delayed fashion.

On the other hand, self._logger is kept in init_app(), so that Flask's log
system has had a chance to initialize. It is not used by the decorator.

Signed-off-by: Dato Simó <dato@net.com.org.es>