### PR TITLE
Use X-Hub-Signature-256

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -56,7 +56,7 @@ class Webhook(object):
     def _get_digest(self):
         """Return message digest if a secret key was provided"""
 
-        return hmac.new(self._secret, request.data, hashlib.sha1).hexdigest() if self._secret else None
+        return hmac.new(self._secret, request.data, hashlib.sha256).hexdigest() if self._secret else None
 
     def _postreceive(self):
         """Callback from Flask"""
@@ -64,11 +64,11 @@ class Webhook(object):
         digest = self._get_digest()
 
         if digest is not None:
-            sig_parts = _get_header("X-Hub-Signature").split("=", 1)
+            sig_parts = _get_header("X-Hub-Signature-256").split("=", 1)
             if not isinstance(digest, six.text_type):
                 digest = six.text_type(digest)
 
-            if len(sig_parts) < 2 or sig_parts[0] != "sha1" or not hmac.compare_digest(sig_parts[1], digest):
+            if len(sig_parts) < 2 or sig_parts[0] != "sha256" or not hmac.compare_digest(sig_parts[1], digest):
                 abort(400, "Invalid signature")
 
         event_type = _get_header("X-Github-Event")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -158,7 +158,7 @@ def test_can_handle_zero_events(webhook, push_request):
 def test_calls_if_signature_is_correct(mock_hmac, app, push_request, secret):
     # GIVEN
     webhook = Webhook(app, secret=secret)
-    push_request.headers["X-Hub-Signature"] = "sha1=hash_of_something"
+    push_request.headers["X-Hub-Signature-256"] = "sha256=hash_of_something"
     push_request.data = b"something"
     handler = mock.Mock()
     mock_hmac.compare_digest.return_value = True
@@ -175,7 +175,7 @@ def test_calls_if_signature_is_correct(mock_hmac, app, push_request, secret):
 def test_does_not_call_if_signature_is_incorrect(mock_hmac, app, push_request):
     # GIVEN
     webhook = Webhook(app, secret="super_secret")
-    push_request.headers["X-Hub-Signature"] = "sha1=hash_of_something"
+    push_request.headers["X-Hub-Signature-256"] = "sha256=hash_of_something"
     push_request.data = b"something"
     handler = mock.Mock()
     mock_hmac.compare_digest.return_value = False


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
This PR switches to `X-Hub-Signature-256` header instead of `X-Hub-Signature` to validate request signatures, based on GitHub [recommendation](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github).

**Testing performed**
Unit tests were updated, and the updated webhook was tested on real events from GitHub.

**Additional context**
Since the updated code will only be used for _new_ events from GitHub (for which GitHub uses SHA256 header now), I don't think this is a breaking change.
