### PR TITLE
Send json list of data returned from hooks

### DIFF
--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -84,10 +84,11 @@ class Webhook(object):
 
         self._logger.info("%s (%s)", _format_event(event_type, data), _get_header("X-Github-Delivery"))
 
+        return_data = []
         for hook in self._hooks.get(event_type, []):
-            hook(data)
+            return_data.append(hook(data))
 
-        return "", 204
+        return json.dumps(return_data), 200
 
 
 def _get_header(key):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #18*

**Describe your changes**
Changes response from 204 to 200 with a json list of data returned from hooks. The hooks' return data shows up in Recent Deliveries body.
![2021-07-22 12_56_29-Window](https://user-images.githubusercontent.com/3004481/126678404-99bf71b7-9d49-451d-a20f-fb1df82d6d5b.png)

**Testing performed**
Tested on github.com with hooks that do not have a return or return JSON serializable data

**Additional context**
If a hook returns content that is not JSON serializable it will throw an error