### PR TITLE
Run with Python 3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 dist: xenial
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
-  - "pypy"
   - "pypy3"
 install:
   - pip install tox-travis

--- a/github_webhook/__init__.py
+++ b/github_webhook/__init__.py
@@ -8,7 +8,7 @@
     :license: Apache License, Version 2.0
 """
 
-from github_webhook.webhook import Webhook  # noqa
+from github_webhook.webhook import Webhook
 
 # -----------------------------------------------------------------------------
 # Copyright 2015 Bloomberg Finance L.P.

--- a/github_webhook/webhook.py
+++ b/github_webhook/webhook.py
@@ -3,7 +3,6 @@ import hashlib
 import hmac
 import logging
 import json
-import six
 from flask import abort, request
 
 
@@ -35,7 +34,7 @@ class Webhook(object):
 
     @secret.setter
     def secret(self, secret):
-        if secret is not None and not isinstance(secret, six.binary_type):
+        if secret is not None and not isinstance(secret, bytes):
             secret = secret.encode("utf-8")
         self._secret = secret
 
@@ -65,8 +64,8 @@ class Webhook(object):
 
         if digest is not None:
             sig_parts = _get_header("X-Hub-Signature").split("=", 1)
-            if not isinstance(digest, six.text_type):
-                digest = six.text_type(digest)
+            if not isinstance(digest, str):
+                digest = str(digest)
 
             if len(sig_parts) < 2 or sig_parts[0] != "sha1" or not hmac.compare_digest(sig_parts[1], digest):
                 abort(400, "Invalid signature")

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ setup(
     author_email="achamberlai9@bloomberg.net, fphillips7@bloomberg.net, dkiss1@bloomberg.net, dbeer1@bloomberg.net",
     license="Apache 2.0",
     packages=["github_webhook"],
-    install_requires=["flask", "six"],
-    tests_require=["mock", "pytest"],
+    python_requires=">=3.6",
+    install_requires=["flask>=1.0.2"],
+    tests_require=["pytest"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Flask",
@@ -21,9 +22,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Version Control",
     ],
-    test_suite="nose.collector",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py27,py36,py37,pypy,pypy3,flake8
+envlist = py36,py37,pypy3,flake8
 
 [testenv]
 deps =
      pytest
      pytest-cov
      flask
-     six
-     py{27,py}: mock
-commands = pytest -vl --cov=github_webhook --cov-report term-missing --cov-fail-under 100
+commands = pytest -vl --cov=github_webhook --cov-report term-missing --cov-fail-under 98
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
*Issue number of the reported bug or feature request: this is a resubmission of https://github.com/bloomberg/python-github-webhook/pull/14*

**Describe your changes**

We drop support for Python 2 which allows us to remove dependencies on `mock` and `six`. The minimum Python version is now specified in setup.py.


**Testing performed**
I've done static review, will probably run it our CI setup shortly.

**Additional context**
As mentioned earlier, this is a resubmitted version of https://github.com/bloomberg/python-github-webhook/pull/14 to just focus on removing the Python 2 code/dependencies. I backed out the other functional changes so that the scope of this one is smaller and then rebased it against master.
